### PR TITLE
Reject nils

### DIFF
--- a/lib/exceptions_tree/display.rb
+++ b/lib/exceptions_tree/display.rb
@@ -25,7 +25,7 @@ module ExceptionsTree
 
     def inspect_exceptions_tree(tree, level)
       output = ''
-      tree.keys.sort {|k1, k2| k1.name <=> k2.name}.each do |class_name|
+      tree.keys.reject {|c| c.name.nil? }.sort {|k1, k2| k1.name <=> k2.name}.each do |class_name|
         output += sprintf("%s%s\n", ('  ' * level), class_name)
         output += inspect_exceptions_tree(tree[class_name], level+1)
       end


### PR DESCRIPTION
Excellent gem, thank you. I was about to write this myself and then found yours.

When I ran it against one of my applications, I got an error:

```
ArgumentError: comparison of Class with Class failed
```

I traced it back to this line. Some of the items in this tree had `nil` names and so removing them fixed it.